### PR TITLE
Fix flag switch order

### DIFF
--- a/lib/gli.rb
+++ b/lib/gli.rb
@@ -359,6 +359,13 @@ module GLI
     -1
   end
 
+  def flag_switch_index(args)
+    args.each_with_index do |item,index|
+      return index if item =~ /^[\-]/
+    end
+    -1
+  end
+
   def clear_nexts # :nodoc:
     @@next_desc = nil
     @@next_arg_name = nil
@@ -408,6 +415,15 @@ module GLI
         command = find_command(command_name)
         raise UnknownCommand.new("Unknown command '#{command_name}'") if !command
         return parse_options_helper(args,
+                                    global_options,
+                                    command,
+                                    Hash.new,
+                                    arguments)
+      elsif((index = flag_switch_index(args)) >= 0)
+        try_me = args[0..index-1]
+        rest = args[index..args.length]
+        new_args = rest + try_me
+        return parse_options_helper(new_args,
                                     global_options,
                                     command,
                                     Hash.new,
@@ -489,7 +505,6 @@ module GLI
                                     arguments)
       end
     end
-
   end
 
   def find_command(name) # :nodoc:

--- a/test/tc_parsing.rb
+++ b/test/tc_parsing.rb
@@ -74,7 +74,7 @@ class TC_testParsing < Test::Unit::TestCase
       c.flag :v
     end
     argv = %w(-x doit)
-    assert_raises(UnknownGlobalArgument) do 
+    assert_raises(UnknownGlobalArgument) do
       global_options,command,command_options,arguments = GLI.parse_options(argv)
     end
   end
@@ -88,7 +88,7 @@ class TC_testParsing < Test::Unit::TestCase
       c.flag :v
     end
     argv = %w(doit -x)
-    assert_raises(UnknownCommandArgument) do 
+    assert_raises(UnknownCommandArgument) do
       global_options,command,command_options,arguments = GLI.parse_options(argv)
     end
   end
@@ -181,7 +181,23 @@ class TC_testParsing < Test::Unit::TestCase
       c.flag [:l,'stuff']
     end
 
-    argv = %w(doit list -l 10)
+    argv = %w(doit -l 10 list)
+    global_options,command,command_options,arguments = GLI.parse_options(argv)
+    assert_equal '10', command_options[:l]
+    assert arguments.include?('list')
+  end
+
+  def test_switch_and_flag_order_with_global
+    GLI.reset
+    argv = %w(-v -f doit list -l 10)
+
+    GLI.switch :v
+    GLI.switch :f
+    GLI.command :doit do |c|
+      c.desc "list stuff"
+      c.flag [:l,'stuff']
+    end
+
     global_options,command,command_options,arguments = GLI.parse_options(argv)
     assert_equal '10', command_options[:l]
     assert arguments.include?('list')


### PR DESCRIPTION
This commit fixes switch/flag order, which can also be specified after command argument.
