### PR TITLE
Set permissions for initconfig to 0600  [gh-58]

### DIFF
--- a/lib/support/initconfig.rb
+++ b/lib/support/initconfig.rb
@@ -23,7 +23,7 @@ module GLI
             config[COMMANDS_KEY][name.to_sym] = {} if command != self
           end
         end
-        File.open(@filename,'w') do |file|
+        File.open(@filename,'w', 0600) do |file|
           YAML.dump(config,file)
         end
       else

--- a/test/tc_gli.rb
+++ b/test/tc_gli.rb
@@ -179,6 +179,14 @@ class TC_testGLI < Test::Unit::TestCase
 
   end
 
+  def test_initconfig_permissions
+    GLI.reset
+    GLI.config_file(@config_file)
+    GLI.run(['initconfig'])
+    oct_mode = "%o" % File.stat(@config_file).mode
+    assert_match /0600$/, oct_mode
+  end
+
   def do_test_flag_create(object)
     description = 'this is a description'
     long_desc = 'this is a very long description'


### PR DESCRIPTION
Set initconfig to 0600 for gh-58.

Note that I don't have a way to test this on windows, but from reading docs I don't think it will break, but windows only uses the user octal and ignores the rest; so I think no impact. 
