### PR TITLE
Update Rakefile scaffolding

### DIFF
--- a/lib/support/scaffold.rb
+++ b/lib/support/scaffold.rb
@@ -87,8 +87,8 @@ EOS
         file.puts <<EOS
 require 'rake/clean'
 require 'rubygems'
-require 'rake/gempackagetask'
-require 'rake/rdoctask'
+require 'rubygems/package_task'
+require 'rdoc/task'
 
 Rake::RDocTask.new do |rd|
   rd.main = "README.rdoc"
@@ -98,7 +98,7 @@ end
 
 spec = eval(File.read('#{project_name}.gemspec'))
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
 end
 
 EOS


### PR DESCRIPTION
Updates the generated Rakefile to remove the following depreciated warnings:

``` shell
~ ❯ gli init dummy search
Creating dir ./dummy/lib...
Creating dir ./dummy/bin...
...
...
~ ❯ cd dummy 
dummy ❯ rake -T
rake/gempackagetask is deprecated.  Use rubygems/package_task instead
WARNING: 'require 'rake/rdoctask'' is deprecated.  Please use 'require 'rdoc/task' (in RDoc 2.4.2+)' instead.
    at /Users/clint/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rake-0.9.2.2/lib/rake/rdoctask.rb
rake clean            # Remove any temporary products.
rake clobber          # Remove any generated file.
rake clobber_package  # Remove package products
...
...
```

I've verified the new Rakefile runs without warnings on 1.8.7, 1.9.2-p290, and 1.9.3-p0. Cucumber features and tests pass, though I looked in the `gli_init` feature and didn't see any tests that covered something like this. 
