### PR TITLE
Adding gli as runtime dependency in gemspec of scaffolded apps

### DIFF
--- a/lib/support/scaffold.rb
+++ b/lib/support/scaffold.rb
@@ -60,6 +60,7 @@ bin/#{project_name}
   s.executables << '#{project_name}'
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
+  s.add_runtime_dependency('gli')
 end
 EOS
       end


### PR DESCRIPTION
needed for gem distribution to other gemsets
