### PR TITLE
Gemspec should include project version file

### DIFF
--- a/lib/support/scaffold.rb
+++ b/lib/support/scaffold.rb
@@ -51,6 +51,7 @@ spec = Gem::Specification.new do |s|
 # Add your other files here if you make them
   s.files = %w(
 bin/#{project_name}
+lib/#{project_name}_version.rb
   )
   s.require_paths << 'lib'
   s.has_rdoc = true


### PR DESCRIPTION
While creating a new gli project last night, I noticed that my suite would not run once the gemspec was compiled.  I tracked this down to the fact that the gem did not include the lib/myproject_version.rb file by default.  Seems proper to include it out of the box.

Thanks for the handy project!
