### PR TITLE
Failing test for negative and non-negatable switch

### DIFF
--- a/test/tc_gli.rb
+++ b/test/tc_gli.rb
@@ -214,6 +214,18 @@ class TC_testGLI < Clean::Test::TestCase
     do_test_switch_create_twice(@app)
     do_test_switch_create_twice(Command.new(:names => :f))
   end
+  
+  def test_non_negatable_negative_switch
+    @app.reset
+    @app.on_error { |ex| raise ex }
+    @app.switch 'no-color', :negatable => false
+    @app.command :smth do |c|
+      c.action do |global, *args|
+        assert global[:"no-color"], "Expected :'no-color' switch to be true"
+      end
+    end
+    @app.run(%w(--no-color smth))
+  end
 
   def test_all_aliases_in_options
     @app.reset


### PR DESCRIPTION
Hi. I believe I found an inconsistency :)

``` ruby
c.desc "Do not use colorful output" 
c.switch 'no-color', :negatable => false
c.action do |global,options,args| 
  formatter = global[:"no-color"] ? PlainFormatter.new : FancyFormatter.new
  # ...
end
```

I think there's no sense keeping such a switch negatable.
And here comes the problem: if I pass `--no-color` when running my app – I'm getting `global[:"no-color"] == false`, which is bearable, as we get no such key in parsed options unless `--no-color` passed, but obviously it is inconvenient.
What I've found is that it's kinda OptionParser behavior, and I decided not to touch the OptionParserFactory, as I'll definitely mess it up :)
So, here is the failing test...
