### PR TITLE
NoWrappingWrapper removes newlines from help output?

### DIFF
--- a/lib/gli/commands/help.rb
+++ b/lib/gli/commands/help.rb
@@ -4,6 +4,7 @@ require 'gli/terminal'
 require 'gli/commands/help_modules/list_formatter'
 require 'gli/commands/help_modules/text_wrapper'
 require 'gli/commands/help_modules/no_wrapping_wrapper'
+require 'gli/commands/help_modules/do_nothing_wrapper'
 require 'gli/commands/help_modules/tty_only_wrapper'
 require 'gli/commands/help_modules/options_formatter'
 require 'gli/commands/help_modules/global_help_format'
@@ -23,6 +24,7 @@ module GLI
       :to_terminal => HelpModules::TextWrapper,
       :never       => HelpModules::NoWrappingWrapper,
       :tty_only    => HelpModules::TTYOnlyWrapper,
+      :none        => HelpModules::DoNothingWrapper,
     }
     # The help command used for the two-level interactive help system
     class Help < Command

--- a/lib/gli/commands/help_modules/do_nothing_wrapper.rb
+++ b/lib/gli/commands/help_modules/do_nothing_wrapper.rb
@@ -1,0 +1,16 @@
+module GLI
+  module Commands
+    module HelpModules
+      # Leaves text formatting exactly as it was received. Doesn't strip anything.
+      class DoNothingWrapper
+        # Args are ignored entirely; this keeps it consistent with the TextWrapper interface
+        def initialize(width,indent)
+        end
+
+        def wrap(text)
+          return String(text)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why does the NoWrappingWrapper remove newlines from help output? Thats exactly what I expected it _not_ to do.

I want to be able to include things like tables and CLI usage examples:

long_desc """
<explanation of my great command>

Example:
$ app command
=> Does something to the first thing!

$ app command -a
=> Does something to all the things!
"""

Now, even with NoWrappingWrapper, I get an output like this:
$ app help command
<explanation of my great command> Example: $ app command => Does something to the first thing! $ app command -a => Does something to all the things!

Whats the best way to handle this?

Should we create a new DoNothingWrapper that actually doesn't reformat the help text at all? Or should NoWrappingWrapper actually behave this way?
