### PR TITLE
Fix small typo in scaffold

### DIFF
--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -339,7 +339,7 @@ EOS
 
 pre do |global,command,options,args|
   # Pre logic here
-  # Return true to proceed; false to abourt and not call the
+  # Return true to proceed; false to abort and not call the
   # chosen command
   # Use skips_pre before a command to skip this block
   # on that command only

--- a/test/apps/todo/bin/todo
+++ b/test/apps/todo/bin/todo
@@ -39,7 +39,7 @@ command [:chained2,:ch2] => [ :second, :first ]
 
 pre do |global,command,options,args|
   # Pre logic here
-  # Return true to proceed; false to abourt and not call the
+  # Return true to proceed; false to abort and not call the
   # chosen command
   # Use skips_pre before a command to skip this block
   # on that command only


### PR DESCRIPTION
Fixes a minor typo in the `pre` command in the scaffold.
