### PR TITLE
check if config dir(s) exist and create them before creating config file

### DIFF
--- a/lib/gli/commands/initconfig.rb
+++ b/lib/gli/commands/initconfig.rb
@@ -49,6 +49,9 @@ module GLI
           end
         end
       end
+
+      FileUtils.mkdir_p(File.dirname(@filename)) unless File.dirname(@filename) == '.'
+
       File.open(@filename,'w', 0600) do |file|
         YAML.dump(config,file)
       end


### PR DESCRIPTION
Simple change.

Given a user sets the GLI config file to be in a dir, `app initconfig` should create the parent dir(s) (if they do not exist) before creating the config file.

```
config_file 'foo/config.yaml'
```
