### PR TITLE
Allow multiple definitions of a command with a block

### DIFF
--- a/lib/gli/dsl.rb
+++ b/lib/gli/dsl.rb
@@ -157,21 +157,25 @@ module GLI
         :skips_post => @skips_post,
         :skips_around => @skips_around,
       }
+      @commands_declaration_order ||= []
       if names.first.kind_of? Hash
         command = GLI::Commands::CompoundCommand.new(self,
                                                      names.first,
                                                      command_options)
         command.parent = self
         commands[command.name] = command
+        @commands_declaration_order << command
       else
         new_command = Command.new(command_options.merge(:names => [names].flatten))
-        command = commands[new_command.name] || new_command
-        command.parent = self
-        commands[command.name] = command
+        command = commands[new_command.name]
+        if command.nil?
+          command = new_command
+          command.parent = self
+          commands[command.name] = command
+          @commands_declaration_order << command
+        end
         yield command
       end
-      @commands_declaration_order ||= []
-      @commands_declaration_order << command
       clear_nexts
     end
     alias :c :command

--- a/test/tc_subcommands.rb
+++ b/test/tc_subcommands.rb
@@ -68,7 +68,21 @@ class TC_testSubCommand < Clean::Test::TestCase
     Then { assert_equal(@ran_command, :add) }
   end
 
-  test_that "we can reopening commands doesn't cause conflicts" do
+  test_that "reopening commands doesn't re-add them to the output" do
+    Given {
+      @app.command :remote do |p|
+        p.command(:add) { }
+      end
+      @app.command :remote do |p|
+        p.command(:new) { }
+      end
+    }
+    command_names = @app.instance_variable_get("@commands_declaration_order").collect { |c| c.name }
+    assert_equal 1, command_names.grep(:remote).size
+  end
+
+
+  test_that "we can reopen commands doesn't cause conflicts" do
     Given {
       @app.command :remote do |p|
         p.command :add do |c|


### PR DESCRIPTION
This allows "reopening" of a command so you can add more
subcommands. Fixes #144, in a roundabout way.
