### PR TITLE
Use git to list files.

### DIFF
--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -63,7 +63,6 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'http://your.website.com'
   s.platform = Gem::Platform::RUBY
   s.summary = 'A description of your project'
-# Add your other files here if you make them
   s.files = `git ls-files`.split("\n")
   s.require_paths << 'lib'
   s.has_rdoc = true


### PR DESCRIPTION
In the scaffold, the gemspec is generated with manual file input. Why not have git list them instead?
