### PR TITLE
Added versions to 'add_development_dependency' calls to reduce gem build warnings

### DIFF
--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -70,9 +70,9 @@ spec = Gem::Specification.new do |s|
   s.rdoc_options << '--title' << '#{project_name}' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'
   s.executables << '#{project_name}'
-  s.add_development_dependency('rake')
-  s.add_development_dependency('rdoc')
-  s.add_development_dependency('aruba')
+  s.add_development_dependency('rake', '~> 0')
+  s.add_development_dependency('rdoc', '~> 0')
+  s.add_development_dependency('aruba', '~> 0')
   s.add_runtime_dependency('gli','#{GLI::VERSION}')
 end
 EOS


### PR DESCRIPTION
When running `gem build [app_name].gemspec` on a GLI project, the following warnings are thrown:

```
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  open-ended dependency on rdoc (>= 0, development) is not recommended
  if rdoc is semantically versioned, use:
    add_development_dependency 'rdoc', '~> 0'
WARNING:  open-ended dependency on aruba (>= 0, development) is not recommended
  if aruba is semantically versioned, use:
    add_development_dependency 'aruba', '~> 0'
```

This change simply adds the recommended version strings into the scaffold.rb file to eliminate the warnings. 
