### PR TITLE
Add passthrough support

### DIFF
--- a/lib/gli/command.rb
+++ b/lib/gli/command.rb
@@ -31,9 +31,9 @@ module GLI
     include CommandSupport
 
     # Commands you want to shell out directly to another program should set
-    # passthrough to true. Any arguments after the passthrough command are
-    # passed as arguments to the command on execution.
-    attr_accessor :passthrough
+    # skip_option_parsing to true. GLI will halt parsing arguments and options
+    # as soon as it hits a command with this flag set.
+    attr_accessor :skip_option_parsing
 
     # Key in an options hash to find the parent's parsed options
     PARENT = Object.new

--- a/lib/gli/command.rb
+++ b/lib/gli/command.rb
@@ -92,11 +92,6 @@ module GLI
       @action = block
     end
 
-    # Read only accessor for the underlying command action.
-    def _action
-      @action
-    end
-
     # Describes this commands action block when it *also* has subcommands.
     # In this case, the GLI::DSL#desc value is the general description of the commands
     # that this command groups, and the value for *this* method documents what

--- a/lib/gli/command.rb
+++ b/lib/gli/command.rb
@@ -30,6 +30,11 @@ module GLI
     include DSL
     include CommandSupport
 
+    # Commands you want to shell out directly to another program should set
+    # passthrough to true. Any arguments after the passthrough command are
+    # passed as arguments to the command on execution.
+    attr_accessor :passthrough
+
     # Key in an options hash to find the parent's parsed options
     PARENT = Object.new
 
@@ -85,6 +90,11 @@ module GLI
     #
     def action(&block)
       @action = block
+    end
+
+    # Read only accessor for the underlying command action.
+    def _action
+      @action
     end
 
     # Describes this commands action block when it *also* has subcommands.

--- a/lib/gli/command.rb
+++ b/lib/gli/command.rb
@@ -19,7 +19,7 @@ module GLI
   #
   #       c.command :tasks do |t| # <- t is an instance of GLI::Command
   #         # this is a "subcommand" of list
-  #         
+  #
   #         t.action do |global,options,args|
   #           # do whatever list tasks should do
   #         end
@@ -31,7 +31,7 @@ module GLI
     include CommandSupport
 
     # Key in an options hash to find the parent's parsed options
-    PARENT = Object.new 
+    PARENT = Object.new
 
     # Create a new command.
     #
@@ -60,7 +60,7 @@ module GLI
       clear_nexts
     end
 
-    # Set the default command if this command has subcommands and the user doesn't 
+    # Set the default command if this command has subcommands and the user doesn't
     # provide a subcommand when invoking THIS command.  When nil, this will show an error and the help
     # for this command; when set, the command with this name will be executed.
     #
@@ -69,15 +69,15 @@ module GLI
       @default_command = command_name
     end
 
-    # Define the action to take when the user executes this command.  Every command should either define this 
+    # Define the action to take when the user executes this command.  Every command should either define this
     # action block, or have subcommands (or both).
     #
     # +block+:: A block of code to execute.  The block will be given 3 arguments:
     #           +global_options+:: A Hash of the _global_ options specified
     #                              by the user, with defaults set and config file values used (if using a config file, see
     #                              GLI::App#config_file)
-    #           +options+:: A Hash of the command-specific options specified by the 
-    #                       user, with defaults set and config file values used (if using a config file, see 
+    #           +options+:: A Hash of the command-specific options specified by the
+    #                       user, with defaults set and config file values used (if using a config file, see
     #                       GLI::App#config_file).
     #           +arguments+:: An Array of Strings representing the unparsed command line arguments
     #           The block's result value is not used; raise an exception or use GLI#exit_now! if you need an early exit based
@@ -124,12 +124,12 @@ module GLI
     #     > todo help list
     #     NAME
     #         list - List things
-    #     
+    #
     #     SYNOPSIS
-    #         todo [global options] list [command options] 
+    #         todo [global options] list [command options]
     #         todo [global options] list [command options]  tasks
     #         todo [global options] list [command options]  contexts
-    #     
+    #
     #     COMMANDS
     #         <default> - list both tasks and contexts
     #         tasks     - list tasks
@@ -142,7 +142,7 @@ module GLI
     # Returns true if this command has the given option defined
     def has_option?(option) #:nodoc:
       option = option.gsub(/^\-+/,'')
-      ((flags.values.map { |_| [_.name,_.aliases] }) + 
+      ((flags.values.map { |_| [_.name,_.aliases] }) +
        (switches.values.map { |_| [_.name,_.aliases] })).flatten.map(&:to_s).include?(option)
     end
 

--- a/lib/gli/command_support.rb
+++ b/lib/gli/command_support.rb
@@ -144,19 +144,19 @@ module GLI
       @default_command
     end
 
-  private
-
-    def send_declarations_to_parent?
-      app = topmost_ancestor.parent
-      app.nil? ? true : (app.subcommand_option_handling_strategy == :legacy)
-    end
-
     def get_action(arguments)
       if @action
         @action
       else
         generate_error_action(arguments)
       end
+    end
+
+  private
+
+    def send_declarations_to_parent?
+      app = topmost_ancestor.parent
+      app.nil? ? true : (app.subcommand_option_handling_strategy == :legacy)
     end
 
     def generate_error_action(arguments)

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -110,7 +110,7 @@ module GLI
 
         loop do
           # Call the action if the command we're handling has been set to passthrough.
-          command._action.call if command.passthrough
+          command.get_action.call if command.passthrough
 
           option_parser_factory       = OptionParserFactory.for_command(command,@accepts)
           option_block_parser         = CommandOptionBlockParser.new(option_parser_factory, self.error_handler)

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -110,7 +110,16 @@ module GLI
 
         loop do
           # Call the action if the command we're handling has been set to passthrough.
-          command.get_action.call if command.passthrough
+          if command.passthrough
+            command.get_action.call
+            # We should almost never hit this, because we expect the command to
+            # do a Kernel#exec, which replaces the current process and passes
+            # the appropriate exit code back to the controlling pty.
+            #
+            # In the case where a user doesn't call a Kernel#exec, exit cleanly
+            # and immediately.
+            exit_now!(0)
+          end
 
           option_parser_factory       = OptionParserFactory.for_command(command,@accepts)
           option_block_parser         = CommandOptionBlockParser.new(option_parser_factory, self.error_handler)

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -98,7 +98,7 @@ module GLI
       end
 
       def error_handler
-        lambda { |message,extra_error_context| 
+        lambda { |message,extra_error_context|
           raise UnknownCommandArgument.new(message,extra_error_context)
         }
       end

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -109,12 +109,15 @@ module GLI
         arguments = nil
 
         loop do
-          # Call the action if the command we're handling has been set to passthrough.
-          if command.passthrough
+          # Call the action if the command wants to skip further option parsing.
+          if command.skip_option_parsing
             command.get_action.call
-            # We should almost never hit this, because we expect the command to
-            # do a Kernel#exec, which replaces the current process and passes
-            # the appropriate exit code back to the controlling pty.
+            # We should almost never hit the next line, because we expect the
+            # command to do a Kernel#exec, which replaces the current process
+            # and passes the appropriate exit code back to the controlling pty.
+            #
+            # Kernel#exec works inconsistently across different versions of
+            # Ruby, so we need a safeguard.
             #
             # In the case where a user doesn't call a Kernel#exec, exit cleanly
             # and immediately.

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -109,6 +109,9 @@ module GLI
         arguments = nil
 
         loop do
+          # Call the action if the command we're handling has been set to passthrough.
+          command._action.call if command.passthrough
+
           option_parser_factory       = OptionParserFactory.for_command(command,@accepts)
           option_block_parser         = CommandOptionBlockParser.new(option_parser_factory, self.error_handler)
           option_block_parser.command = command


### PR DESCRIPTION
As originally proposed and discussed in flapjack/flapjack#553, this PR adds passthrough support to GLI. 

Passthrough is a method to tell GLI to stop parsing arguments and just call the action as-is. 

The motivation for this was twofold:
- Calling the command with --help invoked the GLI help, not the native help provided by whatever command you're calling.
- Elimination of double handling of arguments and options. Without this, the developer needs to replicate all the arguments and options of the command being called within the GLI command definition.

There is also a minor whitespace cleanup. 
