### PR TITLE
Fix rdoc formatter

### DIFF
--- a/lib/gli/commands/rdoc_document_listener.rb
+++ b/lib/gli/commands/rdoc_document_listener.rb
@@ -62,7 +62,7 @@ module GLI
       def switch(name,aliases,desc,long_desc,negatable)
         if negatable
           name = "[no-]#{name}" if name.to_s.length > 1
-          aliases = aliases.map { |_|  _.to_s.length > 1 ? "[no-]#{_}" : _ } 
+          aliases = aliases.map { |_|  _.to_s.length > 1 ? "[no-]#{_}" : _ }
         end
         invocations = ([name] + aliases).map { |_| add_dashes(_) }.join('|')
         @io.puts "#{@nest}=== #{invocations}"
@@ -84,7 +84,7 @@ module GLI
       def command(name,aliases,desc,long_desc,arg_name,arg_options)
         @io.puts "#{@nest}=== Command: <tt>#{([name] + aliases).join('|')} #{@arg_name_formatter.format(arg_name,arg_options,[])}</tt>"
         @io.puts String(desc).strip
-        @io.puts 
+        @io.puts
         @io.puts String(long_desc).strip
         @nest = "#{@nest}="
       end


### PR DESCRIPTION
Running `GLI_DEBUG=true bin/my-cli _doc` fails with the following stack trace. This patch fixes it.

I didn't check why the tests aren't failing even though [todo.feature](https://github.com/davetron5000/gli/blob/gli-2/features/todo.feature#L546) has a test for this formatter.

```
error: undefined method `exe_name' for nil:NilClass
/opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/commands/rdoc_document_listener.rb:23:in `program_desc': undefined method `exe_name' for nil:NilClass (NoMethodError)
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/commands/doc.rb:37:in `document'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/commands/doc.rb:26:in `block in initialize'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/command_support.rb:126:in `call'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/command_support.rb:126:in `execute'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/app_support.rb:290:in `block in call_command'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/app_support.rb:303:in `call'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/app_support.rb:303:in `call_command'
        from /opt/boxen/rbenv/versions/1.9.3-p547/gemsets/my-cli/gems/gli-2.12.2/lib/gli/app_support.rb:81:in `run'
```
