### PR TITLE
Don't mark required options with brackets in full synopsis

### DIFF
--- a/lib/gli/commands/help_modules/full_synopsis_formatter.rb
+++ b/lib/gli/commands/help_modules/full_synopsis_formatter.rb
@@ -27,10 +27,11 @@ module GLI
 
         def sub_options_doc(sub_options)
           sub_options_doc = sub_options.map { |_,option| 
-            option.names_and_aliases.map { |name| 
+            doc = option.names_and_aliases.map { |name|
               CommandLineOption.name_as_string(name,false) + (option.kind_of?(Flag) ? " #{option.argument_name }" : '')
             }.join('|')
-          }.map { |invocations| "[#{invocations}]" }.sort.join(' ').strip
+            option.required?? doc : "[#{doc}]"
+          }.sort.join(' ').strip
         end
 
       private

--- a/lib/gli/switch.rb
+++ b/lib/gli/switch.rb
@@ -31,5 +31,9 @@ module GLI
     def negatable?
       @negatable
     end
+
+    def required?
+      false
+    end
   end
 end


### PR DESCRIPTION
Currently even when a flag is required it shows with `[]` brackets in full synopsis help -- this can be misunderstood as the flag being optional. Fix that.