### PR TITLE
Add autocomplete toggle

### DIFF
--- a/lib/gli/app.rb
+++ b/lib/gli/app.rb
@@ -302,6 +302,16 @@ module GLI
       @argument_handling_strategy = handling_strategy
     end
 
+
+    # Enables/Disables command autocomplete, where partially spelled commands are automatically expanded to their full form
+    # ex: When enabled, executing 'shake' will execute 'shake_hand' (if no 'shake' command is defined)
+    #     When disabled, executing 'shake' will throw an UnknownCommand error
+    #
+    # +bool+:: Boolean value to enable or disable autocomplete, respectively. True by default.
+    def autocomplete_commands(bool)
+      @autocomplete = bool
+    end
+
     private
 
     def load_commands(path)

--- a/lib/gli/app.rb
+++ b/lib/gli/app.rb
@@ -304,12 +304,14 @@ module GLI
 
 
     # Enables/Disables command autocomplete, where partially spelled commands are automatically expanded to their full form
-    # ex: When enabled, executing 'shake' will execute 'shake_hand' (if no 'shake' command is defined)
-    #     When disabled, executing 'shake' will throw an UnknownCommand error
     #
-    # +bool+:: Boolean value to enable or disable autocomplete, respectively. True by default.
-    def autocomplete_commands(bool)
-      @autocomplete = bool
+    # Example:
+    # When enabled, executing 'shake' would execute 'shake_hand' (if no 'shake' command is defined).
+    # When disabled, executing 'shake' would throw an UnknownCommand error
+    #
+    # +boolean+:: Boolean value to enable or disable autocomplete, respectively. True by default.
+    def autocomplete_commands(boolean)
+      @autocomplete = boolean
     end
 
     private

--- a/lib/gli/app_support.rb
+++ b/lib/gli/app_support.rb
@@ -26,6 +26,7 @@ module GLI
       @pre_block = false
       @post_block = false
       @default_command = :help
+      @autocomplete = false
       @around_block = nil
       @subcommand_option_handling_strategy = :legacy
       @argument_handling_strategy = :loose
@@ -69,6 +70,7 @@ module GLI
                                                 switches,
                                                 accepts,
                                                 :default_command => @default_command,
+                                                :autocomplete => autocomplete,
                                                 :subcommand_option_handling_strategy => subcommand_option_handling_strategy,
                                                 :argument_handling_strategy => argument_handling_strategy)
 
@@ -209,6 +211,10 @@ module GLI
 
     def subcommand_option_handling_strategy
       @subcommand_option_handling_strategy || :legacy
+    end
+
+    def autocomplete
+      @autocomplete.nil? ? true : @autocomplete
     end
 
   private

--- a/lib/gli/app_support.rb
+++ b/lib/gli/app_support.rb
@@ -68,9 +68,9 @@ module GLI
                                                 flags,
                                                 switches,
                                                 accepts,
-                                                @default_command,
-                                                self.subcommand_option_handling_strategy,
-                                                self.argument_handling_strategy)
+                                                :default_command => @default_command,
+                                                :subcommand_option_handling_strategy => subcommand_option_handling_strategy,
+                                                :argument_handling_strategy => argument_handling_strategy)
 
         parsing_result = gli_option_parser.parse_options(args)
         parsing_result.convert_to_openstruct! if @use_openstruct

--- a/lib/gli/command_finder.rb
+++ b/lib/gli/command_finder.rb
@@ -22,11 +22,11 @@ module GLI
     # Finds the command with the given name, allowing for partial matches.  Returns the command named by
     # the default command if no command with +name+ matched
     def find_command(name)
-      name ||= options[:default_command]
+      name = String(name || options[:default_command]).strip
 
-      raise UnknownCommand.new("No command name given nor default available") if String(name).strip == ''
+      raise UnknownCommand.new("No command name given nor default available") if name == ''
 
-      command_found = names_to_commands.fetch(name.to_s) do |command_to_match|
+      command_found = names_to_commands.fetch(name) do |command_to_match|
         find_command_by_partial_name(names_to_commands, command_to_match)
       end
       if Array(command_found).empty?

--- a/lib/gli/command_finder.rb
+++ b/lib/gli/command_finder.rb
@@ -1,7 +1,6 @@
 module GLI
   class CommandFinder
     attr_accessor :options
-    attr_accessor :names_to_commands
 
     DEFAULT_OPTIONS = {
       default_command: nil
@@ -9,26 +8,17 @@ module GLI
 
     def initialize(commands, options = {})
       self.options = DEFAULT_OPTIONS.merge(options)
-      self.names_to_commands = {}
-
-      commands.each do |command_name, command|
-        names_to_commands[command_name.to_s] = command
-        Array(command.aliases).each do |command_alias|
-          names_to_commands[command_alias.to_s] = command
-        end
-      end
+      self.commands_with_aliases = expand_with_aliases(commands)
     end
 
-    # Finds the command with the given name, allowing for partial matches.  Returns the command named by
-    # the default command if no command with +name+ matched
     def find_command(name)
       name = String(name || options[:default_command]).strip
-
       raise UnknownCommand.new("No command name given nor default available") if name == ''
 
-      command_found = names_to_commands.fetch(name) do |command_to_match|
-        find_command_by_partial_name(names_to_commands, command_to_match)
+      command_found = commands_with_aliases.fetch(name) do |command_to_match|
+        find_command_by_partial_name(commands_with_aliases, command_to_match)
       end
+
       if Array(command_found).empty?
         raise UnknownCommand.new("Unknown command '#{name}'")
       elsif command_found.kind_of? Array
@@ -38,10 +28,22 @@ module GLI
     end
 
   private
+    attr_accessor :commands_with_aliases
 
-    def find_command_by_partial_name(names_to_commands, command_to_match)
-      partial_matches = names_to_commands.keys.select { |command_name| command_name =~ /^#{command_to_match}/ }
-      return names_to_commands[partial_matches[0]] if partial_matches.size == 1
+    def expand_with_aliases(commands)
+      expanded = {}
+      commands.each do |command_name, command|
+        expanded[command_name.to_s] = command
+        Array(command.aliases).each do |command_alias|
+          expanded[command_alias.to_s] = command
+        end
+      end
+      expanded
+    end
+
+    def find_command_by_partial_name(commands_with_aliases, command_to_match)
+      partial_matches = commands_with_aliases.keys.select { |command_name| command_name =~ /^#{command_to_match}/ }
+      return commands_with_aliases[partial_matches[0]] if partial_matches.size == 1
       partial_matches
     end
   end

--- a/lib/gli/command_finder.rb
+++ b/lib/gli/command_finder.rb
@@ -17,7 +17,14 @@ module GLI
       raise UnknownCommand.new("No command name given nor default available") if name == ''
 
       command_found = commands_with_aliases.fetch(name) do |command_to_match|
-        find_command_by_partial_name(commands_with_aliases, command_to_match) if options[:autocomplete]
+        if options[:autocomplete]
+          found_match = find_command_by_partial_name(commands_with_aliases, command_to_match)
+          if found_match
+            puts "WARNING: You called a command named '#{name}', which does not exist."
+            puts "Continuing under the assumption that you meant '#{found_match.name}'..."
+          end
+          found_match
+        end
       end
 
       if Array(command_found).empty?

--- a/lib/gli/command_finder.rb
+++ b/lib/gli/command_finder.rb
@@ -1,13 +1,20 @@
 module GLI
   class CommandFinder
-    # Initialize a finder on the given list of commands, using default_command as the default if none found
-    def initialize(commands,default_command)
-      @default_command = default_command
-      @names_to_commands = {}
-      commands.each do |command_name,command|
-        @names_to_commands[command_name.to_s] = command
+    attr_accessor :options
+    attr_accessor :names_to_commands
+
+    DEFAULT_OPTIONS = {
+      default_command: nil
+    }
+
+    def initialize(commands, options = {})
+      self.options = DEFAULT_OPTIONS.merge(options)
+      self.names_to_commands = {}
+
+      commands.each do |command_name, command|
+        names_to_commands[command_name.to_s] = command
         Array(command.aliases).each do |command_alias|
-          @names_to_commands[command_alias.to_s] = command
+          names_to_commands[command_alias.to_s] = command
         end
       end
     end
@@ -15,12 +22,12 @@ module GLI
     # Finds the command with the given name, allowing for partial matches.  Returns the command named by
     # the default command if no command with +name+ matched
     def find_command(name)
-      name ||= @default_command
+      name ||= options[:default_command]
 
       raise UnknownCommand.new("No command name given nor default available") if String(name).strip == ''
 
-      command_found = @names_to_commands.fetch(name.to_s) do |command_to_match|
-        find_command_by_partial_name(@names_to_commands, command_to_match)
+      command_found = names_to_commands.fetch(name.to_s) do |command_to_match|
+        find_command_by_partial_name(names_to_commands, command_to_match)
       end
       if Array(command_found).empty?
         raise UnknownCommand.new("Unknown command '#{name}'")

--- a/lib/gli/command_finder.rb
+++ b/lib/gli/command_finder.rb
@@ -19,19 +19,17 @@ module GLI
       command_found = commands_with_aliases.fetch(name) do |command_to_match|
         if options[:autocomplete]
           found_match = find_command_by_partial_name(commands_with_aliases, command_to_match)
-          if found_match
+          if found_match.kind_of? GLI::Command
             puts "WARNING: You called a command named '#{name}', which does not exist."
             puts "Continuing under the assumption that you meant '#{found_match.name}'..."
+          elsif found_match.kind_of?(Array) && !found_match.empty?
+            raise AmbiguousCommand.new("Ambiguous command '#{name}'. It matches #{found_match.sort.join(',')}")
           end
           found_match
         end
       end
 
-      if Array(command_found).empty?
-        raise UnknownCommand.new("Unknown command '#{name}'")
-      elsif command_found.kind_of? Array
-        raise AmbiguousCommand.new("Ambiguous command '#{name}'. It matches #{command_found.sort.join(',')}")
-      end
+      raise UnknownCommand.new("Unknown command '#{name}'") if Array(command_found).empty?
       command_found
     end
 

--- a/lib/gli/command_finder.rb
+++ b/lib/gli/command_finder.rb
@@ -3,7 +3,8 @@ module GLI
     attr_accessor :options
 
     DEFAULT_OPTIONS = {
-      default_command: nil
+      default_command: nil,
+      autocomplete: true
     }
 
     def initialize(commands, options = {})
@@ -16,7 +17,7 @@ module GLI
       raise UnknownCommand.new("No command name given nor default available") if name == ''
 
       command_found = commands_with_aliases.fetch(name) do |command_to_match|
-        find_command_by_partial_name(commands_with_aliases, command_to_match)
+        find_command_by_partial_name(commands_with_aliases, command_to_match) if options[:autocomplete]
       end
 
       if Array(command_found).empty?

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -5,6 +5,7 @@ module GLI
 
     DEFAULT_OPTIONS = {
       :default_command => nil,
+      :autocomplete => true,
       :subcommand_option_handling_strategy => :legacy,
       :argument_handling_strategy => :loose
     }
@@ -12,7 +13,9 @@ module GLI
     def initialize(commands,flags,switches,accepts, options={})
       self.options = DEFAULT_OPTIONS.merge(options)
 
-      command_finder       = CommandFinder.new(commands, :default_command => (options[:default_command] || :help))
+      command_finder       = CommandFinder.new(commands,
+                                               :default_command => (options[:default_command] || :help),
+                                               :autocomplete => options[:autocomplete])
       @global_option_parser = GlobalOptionParser.new(OptionParserFactory.new(flags,switches,accepts),command_finder,flags)
       @accepts              = accepts
       if options[:argument_handling_strategy] == :strict && options[:subcommand_option_handling_strategy] != :normal

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -2,7 +2,7 @@ module GLI
   # Parses the command-line options using an actual +OptionParser+
   class GLIOptionParser
     def initialize(commands,flags,switches,accepts,default_command = nil,subcommand_option_handling_strategy=:legacy,argument_handling_strategy=:loose)
-       command_finder       = CommandFinder.new(commands,default_command || "help")
+       command_finder       = CommandFinder.new(commands, :default_command => (default_command || :help))
       @global_option_parser = GlobalOptionParser.new(OptionParserFactory.new(flags,switches,accepts),command_finder,flags)
       @accepts              = accepts
       @subcommand_option_handling_strategy = subcommand_option_handling_strategy
@@ -120,7 +120,7 @@ module GLI
           arguments = option_block_parser.parse!(arguments)
 
           parsed_command_options[command] = option_parser_factory.options_hash_with_defaults_set!
-          command_finder                  = CommandFinder.new(command.commands,command.get_default_command)
+          command_finder                  = CommandFinder.new(command.commands, :default_command => command.get_default_command)
           next_command_name               = arguments.shift
 
           verify_required_options!(command.flags, command, parsed_command_options[command])
@@ -193,7 +193,7 @@ module GLI
                        end
 
         default_command = command.get_default_command
-        finder = CommandFinder.new(command.commands,default_command.to_s)
+        finder = CommandFinder.new(command.commands, :default_command => default_command.to_s)
 
         begin
           results = [finder.find_command(command_name),arguments[1..-1]]

--- a/test/tc_command_finder.rb
+++ b/test/tc_command_finder.rb
@@ -33,8 +33,7 @@ class TC_testCommandFinder < Clean::Test::TestCase
   end
 
   def test_ambigous_command
-    expected_error_message = "Ambiguous command 'some'. It matches some_command,some_similar_command"
-    assert_raise_with_message(GLI::AmbiguousCommand, expected_error_message) do
+    assert_raise(GLI::AmbiguousCommand) do
       GLI::CommandFinder.new(@app.commands, :default_command => :status).find_command(:some)
     end
   end

--- a/test/tc_command_finder.rb
+++ b/test/tc_command_finder.rb
@@ -15,18 +15,18 @@ class TC_testCommandFinder < Clean::Test::TestCase
 
   def test_unknown_command_name
     assert_raise(GLI::UnknownCommand) do
-      GLI::CommandFinder.new(@app.commands, :status).find_command(:unfindable_command)
+      GLI::CommandFinder.new(@app.commands, :default_command => :status).find_command(:unfindable_command)
     end
   end
 
   def test_no_command_name_without_default
     assert_raise(GLI::UnknownCommand) do
-      GLI::CommandFinder.new(@app.commands, nil).find_command(nil)
+      GLI::CommandFinder.new(@app.commands).find_command(nil)
     end
   end
 
   def test_no_command_name_with_default
-    actual = GLI::CommandFinder.new(@app.commands, :status).find_command(nil)
+    actual = GLI::CommandFinder.new(@app.commands, :default_command => :status).find_command(nil)
     expected = @app.commands[:status]
 
     assert_equal(actual, expected)
@@ -35,12 +35,12 @@ class TC_testCommandFinder < Clean::Test::TestCase
   def test_ambigous_command
     expected_error_message = "Ambiguous command 'some'. It matches some_command,some_similar_command"
     assert_raise_with_message(GLI::AmbiguousCommand, expected_error_message) do
-      GLI::CommandFinder.new(@app.commands, :status).find_command(:some)
+      GLI::CommandFinder.new(@app.commands, :default_command => :status).find_command(:some)
     end
   end
 
   def test_partial_name_with_autocorrect_enabled
-    actual = GLI::CommandFinder.new(@app.commands, :status).find_command(:deploy)
+    actual = GLI::CommandFinder.new(@app.commands, :default_command => :status).find_command(:deploy)
     expected = @app.commands[:deployable]
 
     assert_equal(actual, expected)

--- a/test/tc_command_finder.rb
+++ b/test/tc_command_finder.rb
@@ -46,9 +46,10 @@ class TC_testCommandFinder < Clean::Test::TestCase
     assert_equal(actual, expected)
   end
 
-  # def test_partial_name_with_autocorrect_disabled
-    # assert_raise(GLI::UnknownCommand) do
-    #   try to find command via partial name
-    # end
-  # end
+  def test_partial_name_with_autocorrect_disabled
+    assert_raise(GLI::UnknownCommand) do
+      GLI::CommandFinder.new(@app.commands, :default_command => :status, :autocomplete => false)
+        .find_command(:deploy)
+    end
+  end
 end

--- a/test/tc_command_finder.rb
+++ b/test/tc_command_finder.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class TC_testCommandFinder < Clean::Test::TestCase
+  include TestHelper
+
+  def setup
+    @app = CLIApp.new
+    [:status, :deployable, :some_command, :some_similar_command].each do |command|
+      @app.commands[command] = GLI::Command.new(:names => command)
+    end
+  end
+
+  def teardown
+  end
+
+  def test_unknown_command_name
+    assert_raise(GLI::UnknownCommand) do
+      GLI::CommandFinder.new(@app.commands, :status).find_command(:unfindable_command)
+    end
+  end
+
+  def test_no_command_name_without_default
+    assert_raise(GLI::UnknownCommand) do
+      GLI::CommandFinder.new(@app.commands, nil).find_command(nil)
+    end
+  end
+
+  def test_no_command_name_with_default
+    actual = GLI::CommandFinder.new(@app.commands, :status).find_command(nil)
+    expected = @app.commands[:status]
+
+    assert_equal(actual, expected)
+  end
+
+  def test_ambigous_command
+    expected_error_message = "Ambiguous command 'some'. It matches some_command,some_similar_command"
+    assert_raise_with_message(GLI::AmbiguousCommand, expected_error_message) do
+      GLI::CommandFinder.new(@app.commands, :status).find_command(:some)
+    end
+  end
+
+  def test_partial_name_with_autocorrect_enabled
+    actual = GLI::CommandFinder.new(@app.commands, :status).find_command(:deploy)
+    expected = @app.commands[:deployable]
+
+    assert_equal(actual, expected)
+  end
+
+  # def test_partial_name_with_autocorrect_disabled
+    # assert_raise(GLI::UnknownCommand) do
+    #   try to find command via partial name
+    # end
+  # end
+end


### PR DESCRIPTION
Adds an option to the DSL for enabling/disabling the simple autocomplete feature in `CommandFinder`:
```ruby
autocomplete_commands false
```
Full doc:
![](http://i.imgur.com/0vzSB3V.jpg)

If you're curious, the desire to have this feature comes from https://github.com/sportngin/octopolo/issues/34
We have a `deployable` command in one of our CLI gems and `deploy` in another - and people (more than once) have accidentally marked their feature branches for merging when they intended a deployment :)

Other small tidbits:
* Revamped `CommandFinder` and `GLIOptionParser` to use options hashes in their method signatures. This allows for much greater flexibility in doing something such as this autocomplete feature without constantly just pushing more and more parameters into the method signatures.
* Full tests for `CommandFinder` written before I refactored the class a bit. Things are reordered and pushed around but the functionality (beyond the toggle) should be the same.
* Lastly, I also added (in the spirit of Git-Like-Interface) the same warning you'd see in Git if a command is autocompleted. However, I'm unsure how you interface with the CLI output so the warning does get printed in tests. Any idea/opinion on how I should handle that?

The tests all pass, but do let me know if you see anything fishy that I missed. Thanks Dave!