### PR TITLE
Fixes confusion on switches

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
         <div class="sidebar">
           <h4>What's a "switch" and what's a "flag"?</h4>
           <p>
-          GLI differentates options that take arguments from ones that don't.  Options that don't merely <em>switch</em> something on or
+          GLI differentates options that take arguments from ones that don't.  Options that merely <em>switch</em> something on or
           off, and are called <em>switches</em>.  Options that take an argument are called <em>flags</em>.  The global option
           <code>tasklist</code> is a flag.  As such, it can have a default value, which we specified by using the <code>:default_value</code>
           option.


### PR DESCRIPTION
The documentation was contradictory on what a switch
is. It had both switches and flags stated as doing what
flags handle.

Amos King @adkron amos.l.king@gmail.com
