### PR TITLE
load boolen settings correctly from config

### DIFF
--- a/lib/gli/app_support.rb
+++ b/lib/gli/app_support.rb
@@ -201,7 +201,7 @@ module GLI
 
     def override_default(tokens,config)
       tokens.each do |name,token|
-        token.default_value=config[name] if config[name]
+        token.default_value=config[name] unless config[name].nil?
       end
     end
 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -8,3 +8,4 @@ commands:
     :f: barfoo
 :f: foo
 :bleorgh: true
+:t: false

--- a/test/tc_gli.rb
+++ b/test/tc_gli.rb
@@ -145,6 +145,8 @@ class TC_testGLI < Clean::Test::TestCase
     @app.flag :f
     @app.switch :s
     @app.flag :g
+    @app.default_value true
+    @app.switch :t
     called = false
     @app.command :command do |c|
       c.flag :f
@@ -159,6 +161,7 @@ class TC_testGLI < Clean::Test::TestCase
           assert !o[:f]
           assert !g[:s]
           assert o[:s]
+          assert !g[:t]
         rescue Exception => ex
           failure = ex
         end


### PR DESCRIPTION
We have to check for nil in the config hash instead of false. Otherwise switches with the value false don't override the default value from the application.