### PR TITLE
Include the backtrace when printing the exception message.

### DIFF
--- a/lib/gli/app_support.rb
+++ b/lib/gli/app_support.rb
@@ -284,7 +284,7 @@ module GLI
     # Returns a String of the error message to show the user
     # +ex+:: The exception we caught that launched the error handling routines
     def error_message(ex) #:nodoc:
-      "error: #{ex.message}"
+      "error: #{ex.message}\n#{ex.backtrace.join("\n")}"
     end
 
     def call_command(parsing_result)

--- a/test/tc_command.rb
+++ b/test/tc_command.rb
@@ -397,7 +397,7 @@ class TC_testCommand < Clean::Test::TestCase
     @app.pre { |*| false }
 
     assert_equal 65,@app.run(["bs"]) # BSD for "input data incorrect in some way"
-    assert_contained 'error: preconditions failed',@fake_stderr.to_s
+    assert_contained(@fake_stderr,/error: preconditions failed/)
     assert_equal '',@fake_stdout.to_s
   end
 

--- a/test/tc_command.rb
+++ b/test/tc_command.rb
@@ -397,7 +397,7 @@ class TC_testCommand < Clean::Test::TestCase
     @app.pre { |*| false }
 
     assert_equal 65,@app.run(["bs"]) # BSD for "input data incorrect in some way"
-    assert_equal 'error: preconditions failed',@fake_stderr.to_s
+    assert_contained 'error: preconditions failed',@fake_stderr.to_s
     assert_equal '',@fake_stdout.to_s
   end
 


### PR DESCRIPTION
Minor update. I think the exception backtrace should be included by default with the exception message.