### PR TITLE
Fix multi-arg help formatting

### DIFF
--- a/lib/gli/commands/help_modules/arg_name_formatter.rb
+++ b/lib/gli/commands/help_modules/arg_name_formatter.rb
@@ -22,7 +22,7 @@ module GLI
               arg_desc = "[#{arg_desc}]"
             end
             if arg.multiple?
-              arg_desc = "#{arg_desc}[, #{arg_desc}]*"
+              arg_desc = "#{arg_desc}[ #{arg_desc}]*"
             end
             desc = desc + " " + arg_desc
           end


### PR DESCRIPTION
GLI will not strip comma characters from the end of arguments. If a user
is following the help syntax for a multi-argument, the first to N-1
argument parsed will be incorrect (have an unstripped comma at the end
of the value).
