### PR TITLE
Ruby 2.0.0 is not supported anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ notifications:
     on_success: always
 script: 'bundle exec rake test features'
 rvm:
-  - 2.0.0
   - 2.1.8
   - 2.2.4
   - 2.3.0


### PR DESCRIPTION
@davetron5000 

https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/

Let's save some Travis time :smile: 