### PR TITLE
--version switch takes priority over default_command

### DIFF
--- a/features/todo.feature
+++ b/features/todo.feature
@@ -60,6 +60,13 @@ Feature: The todo app has a nice user interface
     todo version 0.0.1
     """
 
+  Scenario: --version flag displays version instead of executing command
+    When I successfully run `todo --version ls`
+    Then the output should contain:
+    """
+    todo version 0.0.1
+    """
+
   Scenario: Help completion mode
     When I successfully run `todo help -c`
     Then the output should contain:

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -45,7 +45,7 @@ module GLI
       def parse!(parsing_result)
         parsing_result.arguments      = GLIOptionBlockParser.new(@option_parser_factory,UnknownGlobalArgument).parse!(parsing_result.arguments)
         parsing_result.global_options = @option_parser_factory.options_hash_with_defaults_set!
-        command_name = if parsing_result.global_options[:help]
+        command_name = if parsing_result.global_options[:help] || parsing_result.global_options[:version]
                          "help"
                        else
                          parsing_result.arguments.shift

--- a/test/tc_help.rb
+++ b/test/tc_help.rb
@@ -58,7 +58,7 @@ class TC_testHelp < Clean::Test::TestCase
     }
   end
 
-  test_that "the help command can be configured to skip things declaratively regardless of when it the object was created" do
+  test_that "the help command can be configured to skip things declaratively regardless of when the object was created" do
     Given {
       GLI::Commands::Help.skips_pre    = false
       GLI::Commands::Help.skips_post   = false


### PR DESCRIPTION
As mentioned in #206, --version switch should take priority over default_command.
