### PR TITLE
Fix scaffold issue #207

### DIFF
--- a/features/gli_init.feature
+++ b/features/gli_init.feature
@@ -57,17 +57,17 @@ Feature: The scaffold GLI generates works
 
     SYNOPSIS
         todo [global options] command [command options] [arguments...]
-    
+
     VERSION
         0.0.1
-    
+
     GLOBAL OPTIONS
         -f, --flagname=The name of the argument - Describe some flag here (default:
                                                   the default)
         --help                                  - Show this message
         -s, --[no-]switch                       - Describe some switch here
         --version                               - Display the program version
-    
+
     COMMANDS
         add      - Describe add here
         complete - Describe complete here
@@ -83,17 +83,17 @@ Feature: The scaffold GLI generates works
 
     SYNOPSIS
         todo [global options] command [command options] [arguments...]
-    
+
     VERSION
         0.0.1
-    
+
     GLOBAL OPTIONS
         -f, --flagname=The name of the argument - Describe some flag here (default:
                                                   the default)
         --help                                  - Show this message
         -s, --[no-]switch                       - Describe some switch here
         --version                               - Display the program version
-    
+
     COMMANDS
         add      - Describe add here
         complete - Describe complete here
@@ -121,12 +121,8 @@ Feature: The scaffold GLI generates works
     When I run `rake test`
     Then the output should contain:
     """
-    .
-    """
-    And the output should contain:
-    """
 
-    1 tests, 1 assertions, 0 failures, 0 errors
+    1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
     """
     Given todo's libs are no longer in my load path
     When I run `rake features`
@@ -191,7 +187,7 @@ Feature: The scaffold GLI generates works
      When I run `bin/todo foobar`
      Then the stderr should contain "error: Unknown command 'foobar'"
       And the exit status should not be 0
-     
+
   Scenario: Running commands using short form
     Given I successfully run `gli init todo add complete compute list`
       And I cd to "todo"
@@ -202,7 +198,7 @@ Feature: The scaffold GLI generates works
      Then the output should contain "list command ran"
      When I successfully run `bin/todo compl`
      Then the output should contain "complete command ran"
-     
+
   Scenario: Ambiguous commands give helpful output
     Given I successfully run `gli init todo add complete compute list`
       And I cd to "todo"
@@ -210,7 +206,7 @@ Feature: The scaffold GLI generates works
      When I run `bin/todo comp`
      Then the stderr should contain "Ambiguous command 'comp'. It matches complete,compute"
      And the exit status should not be 0
-     
+
   Scenario: Running generated command without bundler gives a helpful error message
     Given I successfully run `gli init todo add complete compute list`
       And I cd to "todo"
@@ -219,7 +215,7 @@ Feature: The scaffold GLI generates works
      Then the stderr should contain "In development, you need to use `bundle exec bin/todo` to run your app"
      And the stderr should contain "At install-time, RubyGems will make sure lib, etc. are in the load path"
      And the stderr should contain "Feel free to remove this message from bin/todo now"
-     
+
   Scenario: Running commands with a dash in the name
     Given I successfully run `gli init todo-app add complete compute list`
       And I cd to "todo-app"

--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -55,7 +55,7 @@ module GLI
         file.puts <<EOS
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','#{project_name}','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = '#{project_name}'
   s.version = #{project_name_as_module_name(project_name)}::VERSION
   s.author = 'Your Name Here'
@@ -171,7 +171,7 @@ EOS
             test_file.puts <<EOS
 require 'test_helper'
 
-class DefaultTest < Test::Unit::TestCase
+class DefaultTest < Minitest::Test
 
   def setup
   end
@@ -188,14 +188,14 @@ EOS
           puts "Created #{root_dir}/#{project_name}/test/default_test.rb"
           File.open("#{root_dir}/#{project_name}/test/test_helper.rb",'w') do |test_file|
             test_file.puts <<EOS
-require 'test/unit'
+require 'minitest/autorun'
 
 # Add test libraries you want to use here, e.g. mocha
 
-class Test::Unit::TestCase
+class Minitest::Test
 
   # Add global extensions to the test case class here
-  
+
 end
 EOS
           end
@@ -314,7 +314,7 @@ command :#{command} do |c|
   c.action do |global_options,options,args|
 
     # Your command logic here
-     
+
     # If you have any errors, just raise them
     # raise "that command made no sense"
 


### PR DESCRIPTION
This fixes issue #207 for me, although the actual default feature test appears to not work. Not sure why, having no experience with it.

Please note Aruba version 0.8.1 is apparently **not** required as opposed to what is mentioned in #207 by @louisrousseau. Gem minitest was also not required.

Tested locally against Ruby 2.1.3 with the following gems:
```
Resolving dependencies...
Using rake 12.0.0
Using ffi 1.9.14
Using contracts 0.14.0
Using builder 3.2.2
Using gherkin 4.0.0
Using cucumber-wire 0.0.1
Using diff-lcs 1.2.5
Using multi_json 1.12.1
Using multi_test 0.1.2
Using rspec-support 3.5.0
Using thor 0.19.4
Using gli 2.14.0
Using rdoc 5.0.0
Using bundler 1.13.7
Using childprocess 0.5.9
Using cucumber-core 1.5.0
Using rspec-expectations 3.5.0
Using todo 0.0.1 from source at `.`
Using cucumber 2.4.0
Using aruba 0.14.2
```