### PR TITLE
Fix basic bootstrap

### DIFF
--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -63,7 +63,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'http://your.website.com'
   s.platform = Gem::Platform::RUBY
   s.summary = 'A description of your project'
-  s.files = `git ls-files`.split("\n")
+  s.files = `git ls-files`.split("\\n")
   s.require_paths << 'lib'
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','#{project_name}.rdoc']

--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -73,6 +73,7 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
   s.add_development_dependency('aruba')
+  s.add_development_dependency('test-unit')
   s.add_runtime_dependency('gli','#{GLI::VERSION}')
 end
 EOS


### PR DESCRIPTION
584334b addresses the weirdness about rendering an actual newline instead of the escape sequence.

33c7871 adds `test-unit` as a dev dep so the first `bundle exec rake test` will work. Otherwise you get the following:

```
/Users/max/Dropbox/work/src/github.com/mbigras/gli/some_gli/test/test_helper.rb:1:in `require': cannot load such file -- test/unit (LoadError)
	from /Users/max/Dropbox/work/src/github.com/mbigras/gli/some_gli/test/test_helper.rb:1:in `<top (required)>'
	from /Users/max/Dropbox/work/src/github.com/mbigras/gli/some_gli/test/default_test.rb:1:in `require'
	from /Users/max/Dropbox/work/src/github.com/mbigras/gli/some_gli/test/default_test.rb:1:in `<top (required)>'
	from /Users/max/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `require'
	from /Users/max/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	from /Users/max/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /Users/max/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1)
/Users/max/.rbenv/versions/2.2.2/bin/bundle:23:in `load'
/Users/max/.rbenv/versions/2.2.2/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

I could also rewrite the bootstrapped test case to use Minitest which might be better because then we don't need to add the dependency.

What do you think?