### PR TITLE
Fix: has_rdoc has been deprecated (defaults to true) since rubygems 1.3.3

### DIFF
--- a/gli.gemspec
+++ b/gli.gemspec
@@ -17,7 +17,6 @@ spec = Gem::Specification.new do |s|
   s.executables   =  'gli'
   s.require_paths = ["lib"]
 
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'gli.rdoc']
   s.rdoc_options << '--title' << 'Git Like Interface' << '--main' << 'README.rdoc'
   s.bindir = 'bin'

--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -55,7 +55,7 @@ module GLI
         file.puts <<EOS
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','#{project_name}','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = '#{project_name}'
   s.version = #{project_name_as_module_name(project_name)}::VERSION
   s.author = 'Your Name Here'
@@ -65,7 +65,6 @@ spec = Gem::Specification.new do |s|
   s.summary = 'A description of your project'
   s.files = `git ls-files`.split("\n")
   s.require_paths << 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','#{project_name}.rdoc']
   s.rdoc_options << '--title' << '#{project_name}' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'
@@ -195,7 +194,7 @@ require 'test/unit'
 class Test::Unit::TestCase
 
   # Add global extensions to the test case class here
-  
+
 end
 EOS
           end
@@ -314,7 +313,7 @@ command :#{command} do |c|
   c.action do |global_options,options,args|
 
     # Your command logic here
-     
+
     # If you have any errors, just raise them
     # raise "that command made no sense"
 

--- a/test/apps/todo/todo.gemspec
+++ b/test/apps/todo/todo.gemspec
@@ -1,6 +1,6 @@
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','todo','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = 'todo'
   s.version = Todo::VERSION
   s.author = 'Your Name Here'
@@ -13,7 +13,6 @@ spec = Gem::Specification.new do |s|
 bin/todo
   )
   s.require_paths << 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','todo.rdoc']
   s.rdoc_options << '--title' << 'todo' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'

--- a/test/apps/todo_legacy/todo.gemspec
+++ b/test/apps/todo_legacy/todo.gemspec
@@ -1,6 +1,6 @@
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','todo','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = 'todo'
   s.version = Todo::VERSION
   s.author = 'Your Name Here'
@@ -13,7 +13,6 @@ spec = Gem::Specification.new do |s|
 bin/todo
   )
   s.require_paths << 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','todo.rdoc']
   s.rdoc_options << '--title' << 'todo' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'


### PR DESCRIPTION
This causes `cucumber features/gli_init.feature` to fail with current versions of rubygems. The option hasn't been used since 2009 so I think we're ok just removing it ;) 