### PR TITLE
Updated development dependencies.

### DIFF
--- a/gli.gemspec
+++ b/gli.gemspec
@@ -25,9 +25,9 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '~> 4.2')
   s.add_development_dependency('rainbow', '~> 1.1', '~> 1.1.1')
   s.add_development_dependency('clean_test', '~> 1.0')
-  s.add_development_dependency('cucumber', '~> 2.4')
-  s.add_development_dependency('gherkin', '~> 4.0')
-  s.add_development_dependency('aruba', '0.5.1')
+  s.add_development_dependency('cucumber', '~> 3.1.2')
+  s.add_development_dependency('gherkin', '~> 5.1.0')
+  s.add_development_dependency('aruba', '~> 0.7.4')
   s.add_development_dependency('sdoc', '~> 0.4')
-  s.add_development_dependency('faker','1.0.0')
+  s.add_development_dependency('faker','~> 1.9.1')
 end

--- a/gli.gemspec
+++ b/gli.gemspec
@@ -17,7 +17,6 @@ spec = Gem::Specification.new do |s|
   s.executables   =  'gli'
   s.require_paths = ["lib"]
 
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'gli.rdoc']
   s.rdoc_options << '--title' << 'Git Like Interface' << '--main' << 'README.rdoc'
   s.bindir = 'bin'

--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -55,7 +55,7 @@ module GLI
         file.puts <<EOS
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','#{project_name}','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = '#{project_name}'
   s.version = #{project_name_as_module_name(project_name)}::VERSION
   s.author = 'Your Name Here'
@@ -65,7 +65,6 @@ spec = Gem::Specification.new do |s|
   s.summary = 'A description of your project'
   s.files = `git ls-files`.split("\n")
   s.require_paths << 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','#{project_name}.rdoc']
   s.rdoc_options << '--title' << '#{project_name}' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'
@@ -195,7 +194,7 @@ require 'test/unit'
 class Test::Unit::TestCase
 
   # Add global extensions to the test case class here
-  
+
 end
 EOS
           end
@@ -314,7 +313,7 @@ command :#{command} do |c|
   c.action do |global_options,options,args|
 
     # Your command logic here
-     
+
     # If you have any errors, just raise them
     # raise "that command made no sense"
 

--- a/test/apps/todo/todo.gemspec
+++ b/test/apps/todo/todo.gemspec
@@ -1,6 +1,6 @@
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','todo','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = 'todo'
   s.version = Todo::VERSION
   s.author = 'Your Name Here'
@@ -13,7 +13,6 @@ spec = Gem::Specification.new do |s|
 bin/todo
   )
   s.require_paths << 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','todo.rdoc']
   s.rdoc_options << '--title' << 'todo' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'

--- a/test/apps/todo_legacy/todo.gemspec
+++ b/test/apps/todo_legacy/todo.gemspec
@@ -1,6 +1,6 @@
 # Ensure we require the local version and not one we might have installed already
 require File.join([File.dirname(__FILE__),'lib','todo','version.rb'])
-spec = Gem::Specification.new do |s| 
+spec = Gem::Specification.new do |s|
   s.name = 'todo'
   s.version = Todo::VERSION
   s.author = 'Your Name Here'
@@ -13,7 +13,6 @@ spec = Gem::Specification.new do |s|
 bin/todo
   )
   s.require_paths << 'lib'
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc','todo.rdoc']
   s.rdoc_options << '--title' << 'todo' << '--main' << 'README.rdoc' << '-ri'
   s.bindir = 'bin'


### PR DESCRIPTION
Updating aruba and some other dependencies to get rid of this:

```
DEPRECATION: Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/dblock/.rvm/gems/ruby-2.4.2/gems/aruba-0.5.1/lib/aruba/api.rb:239:in `assert_exit_status'.
```

This isn't the latest version of Aruba, which causes some new problems.

Related: https://stackoverflow.com/questions/28298665/aruba-not-working-with-rspec-3

On top of #276 