### PR TITLE
Initialize git when generating new project

### DIFF
--- a/features/gli_init.feature
+++ b/features/gli_init.feature
@@ -35,6 +35,7 @@ Feature: The scaffold GLI generates works
        |todo/bin  |
        |todo/test |
        |todo/lib  |
+       |todo/.git |
      And the following files should exist:
        |todo/bin/todo              |
        |todo/README.rdoc           |

--- a/lib/gli/commands/scaffold.rb
+++ b/lib/gli/commands/scaffold.rb
@@ -31,6 +31,7 @@ module GLI
           end
           puts "Created #{rvmrc}"
         end
+        init_git(root_dir, project_name)
       end
     end
 
@@ -367,6 +368,14 @@ EOS
         return false
       end
       true
+    end
+
+    def self.init_git(root_dir, project_name)
+      project_dir = "#{root_dir}/#{project_name}"
+
+      unless system("git", "init", "--quiet", project_dir)
+        puts "There was a problem initializing Git. Your gemspec may not work until you have done a successful `git init`"
+      end
     end
 
     def self.mkdirs(dirs,force,dry_run)


### PR DESCRIPTION
I just started a new project and realized that Git wasn't initialized, which doesn't even allow tests to be run since the generated `gemspec` requires only files in Git. Just to avoid users to run the `git init` command themselves :-)