### PR TITLE
Clarify CLI syntax for multi-value arguments

### DIFF
--- a/bin/gli
+++ b/bin/gli
@@ -36,7 +36,7 @@ long_desc <<EOS
 EOS
   arg :project_name
   arg :command_name, [:optional, :multiple]
-  arg_name "project_name [command_name][, [command_name]]*"
+  arg_name "project_name [command_name]..."
   command [:init,:scaffold] do |c|
 
     c.switch :e,:ext, :desc => 'Create an ext dir'

--- a/features/gli_executable.feature
+++ b/features/gli_executable.feature
@@ -49,7 +49,7 @@ Feature: The GLI executable works as intended
         init - Create a new GLI-based project
 
     SYNOPSIS
-        gli [global options] init [command options] project_name [command_name][, [command_name]]*
+        gli [global options] init [command options] project_name [command_name]...
 
     DESCRIPTION
         This will create a scaffold command line project that uses GLI for command

--- a/features/todo.feature
+++ b/features/todo.feature
@@ -191,7 +191,7 @@ Feature: The todo app has a nice user interface
         list - List things, such as tasks or contexts
 
     SYNOPSIS
-        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task][, [task]]*
+        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task]...
         todo [global options] list [command options] contexts [--otherflag arg] [-b] [-f|--foobar]
 
     DESCRIPTION
@@ -261,7 +261,7 @@ Feature: The todo app has a nice user interface
         list - List things, such as tasks or contexts
 
     SYNOPSIS
-        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task][, [task]]*
+        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task]...
         todo [global options] list [command options] contexts [--otherflag arg] [-b] [-f|--foobar]
 
     DESCRIPTION
@@ -286,7 +286,7 @@ Feature: The todo app has a nice user interface
         list - List things, such as tasks or contexts
 
     SYNOPSIS
-        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task][, [task]]*
+        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task]...
         todo [global options] list [command options] contexts [--otherflag arg] [-b] [-f|--foobar]
 
     DESCRIPTION
@@ -319,7 +319,7 @@ Feature: The todo app has a nice user interface
         list - List things, such as tasks or contexts
 
     SYNOPSIS
-        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task][, [task]]*
+        todo [global options] list [command options] [tasks] [--flag arg] [-x arg] [task]...
         todo [global options] list [command options] contexts [--otherflag arg] [-b] [-f|--foobar]
 
     DESCRIPTION
@@ -343,7 +343,7 @@ Feature: The todo app has a nice user interface
         tasks - List tasks
 
     SYNOPSIS
-        todo [global options] list tasks [command options] [task][, [task]]*
+        todo [global options] list tasks [command options] [task]...
         todo [global options] list tasks [command options] open [--flag arg] [-x arg]
 
     DESCRIPTION
@@ -370,9 +370,9 @@ Feature: The todo app has a nice user interface
         todo [global options] create 
         todo [global options] create contexts [context_name]
         todo [global options] create relation_1-1 first second [name]
-        todo [global options] create relation_1-n first second[, second]* [name]
-        todo [global options] create relation_n-1 first[, first]* second [name]
-        todo [global options] create tasks task_name[, task_name]*
+        todo [global options] create relation_1-n first second... [name]
+        todo [global options] create relation_n-1 first... second [name]
+        todo [global options] create tasks task_name...
 
     COMMANDS
         <default>    - Makes a new task
@@ -530,7 +530,7 @@ Feature: The todo app has a nice user interface
         list - List things, such as tasks or contexts
 
     SYNOPSIS
-        todo [global options] list [command options] [tasks] [subcommand options] [task][, [task]]*
+        todo [global options] list [command options] [tasks] [subcommand options] [task]...
         todo [global options] list [command options] contexts [subcommand options]
 
     DESCRIPTION

--- a/features/todo_legacy.feature
+++ b/features/todo_legacy.feature
@@ -92,7 +92,7 @@ Feature: The todo app is backwards compatible with legacy subcommand parsing
     SYNOPSIS
         todo [global options] create 
         todo [global options] create contexts [context_name]
-        todo [global options] create tasks task_name[, task_name]*
+        todo [global options] create tasks task_name...
 
     COMMANDS
         <default> - Makes a new task

--- a/lib/gli/commands/help_modules/arg_name_formatter.rb
+++ b/lib/gli/commands/help_modules/arg_name_formatter.rb
@@ -22,7 +22,7 @@ module GLI
               arg_desc = "[#{arg_desc}]"
             end
             if arg.multiple?
-              arg_desc = "#{arg_desc}[, #{arg_desc}]*"
+              arg_desc = "#{arg_desc}..."
             end
             desc = desc + " " + arg_desc
           end
@@ -37,7 +37,7 @@ module GLI
             desc = "[#{desc}]"
           end
           if arguments_options.include? :multiple
-            desc = "#{desc}[, #{desc}]*"
+            desc = "#{desc}..."
           end
           " " + desc
         end

--- a/lib/gli/dsl.rb
+++ b/lib/gli/dsl.rb
@@ -50,7 +50,7 @@ module GLI
     #     command :pack do ...
     #
     # Produces the synopsis:
-    #     app.rb [global options] pack output input[, input]*
+    #     app.rb [global options] pack output input...
     def arg(name, options=[])
       @next_arguments ||= []
       @next_arguments << Argument.new(name, Array(options).flatten)


### PR DESCRIPTION
GLI will not strip comma characters from the end of arguments. If a user
is following the help syntax for a multi-value argument, the first to
N-1 values parsed will be incorrect (have an unstripped comma at the
end of the value). Solve this by printing the argument name only once,
followed by '...' directly. This is similar to the behaviour of git.

Signed-off-by: Florian Pritz <bluewind@xinu.at>