### PR TITLE
Allow more time for slow tests

### DIFF
--- a/features/gli_init.feature
+++ b/features/gli_init.feature
@@ -8,6 +8,7 @@ Feature: The scaffold GLI generates works
       And GLI's libs are in my path
       And my terminal size is "80x24"
 
+  @slow-command
   Scenario: Scaffold generates and things look good
     When I run `gli init --rvmrc todo add complete list`
     Then the exit status should be 0

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,5 @@
+require 'aruba/cucumber'
+
+Before '@slow-command' do
+    @aruba_timeout_seconds = 10
+end


### PR DESCRIPTION
The default we are using for all tests is 5 seconds;
This is not enough to run `rake` during one of the test;
Added a bit more time for that specific test.

Signed-off-by: Jean-Sebastien Gelinas <calestar@gmail.com>