### PR TITLE
Fix link to optparse-plus

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
       <code>git</code> or <code>gem</code> (GLI stands for "Git-Like Interface").  GLI uses a 
       simple DSL, but retains all the power you'd expect from the built-int <code>OptionParser</code>.
       <span class="note">If you're looking to make a vanilla CLI app that doesn't need command support, 
-      be sure to check out <a href="http://davetron5000.github.com/methadone">Methadone</a>, which gives you all the power
+      be sure to check out <a href="http://davetron5000.github.io/optparse-plus/">optparse-plus</a>, which gives you all the power
       of <code>OptionParser</code>, but none of the verbosity</span>.
       </p>
       <p>


### PR DESCRIPTION
Looks like it was renamed, but this link is still hanging around.