### PR TITLE
Add a `command_missing` hook

### DIFF
--- a/lib/gli/app_support.rb
+++ b/lib/gli/app_support.rb
@@ -15,6 +15,7 @@ module GLI
       switches.clear
       flags.clear
       @commands = nil
+      @command_missing_block = nil
       @commands_declaration_order = []
       @flags_declaration_order = []
       @switches_declaration_order = []
@@ -72,7 +73,8 @@ module GLI
                                                 :default_command => @default_command,
                                                 :autocomplete => autocomplete,
                                                 :subcommand_option_handling_strategy => subcommand_option_handling_strategy,
-                                                :argument_handling_strategy => argument_handling_strategy)
+                                                :argument_handling_strategy => argument_handling_strategy,
+                                                :command_missing_block => @command_missing_block)
 
         parsing_result = gli_option_parser.parse_options(args)
         parsing_result.convert_to_openstruct! if @use_openstruct

--- a/lib/gli/dsl.rb
+++ b/lib/gli/dsl.rb
@@ -204,6 +204,10 @@ module GLI
     end
     alias :c :command
 
+    def command_missing(&block)
+      @command_missing_block = block
+    end
+
     def flags_declaration_order # :nodoc:
       @flags_declaration_order ||= []
     end

--- a/lib/gli/dsl.rb
+++ b/lib/gli/dsl.rb
@@ -201,6 +201,7 @@ module GLI
       end
       clear_nexts
       @next_arguments = []
+      command
     end
     alias :c :command
 

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -54,11 +54,16 @@ module GLI
         parsing_result.command        = begin
           @command_finder.find_command(command_name)
         rescue UnknownCommand => e
-          if @options[:command_missing_block]
-            command = @options[:command_missing_block].call(command_name.to_sym, parsing_result.global_options)
-            raise e unless command
-            command
+          raise e unless @options[:command_missing_block]
+          command = @options[:command_missing_block].call(command_name.to_sym,parsing_result.global_options)
+          if command
+            unless command.is_a?(Command)
+              raise UnknownCommand.new("Expected the `command_missing` block to return a GLI::Command object, got a #{command.class.name} instead.")
+            end
+          else
+            raise e
           end
+          command
         end
 
         unless command_name == 'help'

--- a/test/unit/gli_test.rb
+++ b/test/unit/gli_test.rb
@@ -783,6 +783,36 @@ class GLITest < MiniTest::Test
     assert_equal %w(-f some_flag foo bar blah),argv
   end
 
+  def test_missing_command
+    @called = false
+    @app.command_missing do |command_name, global_options|
+      @app.command command_name do |c|
+        c.action do
+          @called = true
+        end
+      end
+    end
+
+    assert_equal 0, @app.run(['foobar']),"Expected exit status to be 0"
+    assert @called,"Expected missing command to be called"
+  end
+
+  def test_missing_command_not_handled
+    @app.command_missing do |command_name, global_options|
+      # do nothing, i.e. don't handle the command
+    end
+
+    assert_equal 64,@app.run(['foobar']),"Expected exit status to be 64"
+  end
+
+  def test_missing_command_returns_non_command_object
+    @app.command_missing do |command_name, global_options|
+      true
+    end
+
+    assert_equal 64,@app.run(['foobar']),"Expected exit status to be 64"
+  end
+
   private
 
   def do_test_flag_create(object)


### PR DESCRIPTION
First off, thank you so much for GLI. I'm a huge fan ❤️ 

I'd like to propose adding a new hook called `command_missing` which works much like Ruby's `method_missing` method. `command_missing` is called whenever a top-level command can't be found, and expects the block it captures to return an instance of `GLI::Command`.

I'm the author of the [Kuby](https://getkuby.io) project, a tool for deploying Rails apps. Kuby features a plugin system, and therein lies my use-case. I would like plugins to have the ability to specify their own sets of commands, eg. `kuby plugin_name plugin_subcommand ...` The problem is that the list of plugins isn't known until the config file is loaded, which happens in a GLI `pre` hook. I need to be able to defer defining commands until the config file has been loaded, but before all the CLI options have been parsed. With the changes in this PR, the following is now possible:

```ruby
module Kuby
  class Commands
    extend GLI::App

    def self.load_kuby_config!(global_options)
      # loading stuff here
    end

    command_missing do |command_name, global_options|
      load_kuby_config!(global_options)

      # command_name is also the name of the plugin
      if plugin_klass = Kuby.plugins.find(command_name)
        if plugin_klass.respond_to?(:commands)
          desc "Run commands for the #{command_name} plugin."
          command command_name do |c|
            # the plugin now defines its own commands on c
            plugin_klass.commands(c)
          end
        end
      end
    end

    pre do |global_options, options, args|
      load_kuby_config!
      # more code here
    end
  end
end
```

One of the key changes here is that the `command` method now returns the command object, and since that's the last line of the `command_missing` block, it gets returned to the parser. It's a bit funky to be sure, but it works.

Let me know what you think!