### PR TITLE
Fix broken integration test on Ruby 3.2 due to `File.exists?`

### DIFF
--- a/test/integration/gli_powered_app_test.rb
+++ b/test/integration/gli_powered_app_test.rb
@@ -36,7 +36,7 @@ class GLIPoweredAppTest < MiniTest::Test
 
   def test_doc_generation
     out, err, status = run_app("_doc", return_err_and_status: true)
-    assert File.exists?("todo.rdoc")
+    assert File.exist?("todo.rdoc")
   end
 
 private


### PR DESCRIPTION
The `File.exists?` method has long been deprecated. In Ruby 3.2 it was finally removed. This caused one of GLI's integration tests to fail on Ruby 3.2:

```
  1) Error:
GLIPoweredAppTest#test_doc_generation:
NoMethodError: undefined method `exists?' for File:Class
    /Users/mbrictson/Code/davetron5000/gli/test/integration/gli_powered_app_test.rb:39:in `test_doc_generation'
```

Fix by replacing `File.exists?` with `File.exist?`.