### PR TITLE
Add Ruby 3.1 and 3.2 to the CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ workflows:              # keyword
             parameters: # keyword
               # All rubies being maintained per this page:
               # https://www.ruby-lang.org/en/downloads/branches/
-              ruby-version: [ "2.5", "2.6", "2.7", "3.0" ]
+              ruby-version: [ "2.5", "2.6", "2.7", "3.0", "3.1", "3.2" ]


### PR DESCRIPTION
This should be merged after #316 (Fix broken integration test on Ruby 3.2 due to File.exists?) is merged.