### PR TITLE
Fix Rakefile typo that caused default rake task to fail

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,5 +106,5 @@ end
 desc 'Publish rdoc on github pages and push to github'
 task :publish_rdoc => [:rdoc,:publish]
 
-task :default => ["test:unit", "test:integraton"]
+task :default => ["test:unit", "test:integration"]
 


### PR DESCRIPTION
The Rakefile had a typo that caused the default rake task to fail:

```
$ bin/rake
rake aborted!
Don't know how to build task 'test:integraton' (See the list of available tasks with `rake --tasks`)
Did you mean?  test:integration
```

Fix "integraton" → "integration"