### PR TITLE
required flags multiple handles empty array

### DIFF
--- a/dx/build
+++ b/dx/build
@@ -35,7 +35,7 @@ log "✨" "Creating docker-compose.dx.yml"
 compose_file="docker-compose.dx.yml"
 log "🗑️" "Deleting previous ${compose_file}"
 
-rm "${compose_file}"
+rm -f "${compose_file}"
 echo "# THIS IS GENERATED - DO NOT EDIT" > "${compose_file}"
 echo "" >> "${compose_file}"
 echo "services:" >> "${compose_file}"
@@ -54,7 +54,7 @@ for ruby_version in ${RUBY_VERSIONS[@]}; do
   echo "    entrypoint: /root/show-help-in-app-container-then-wait.sh" >> "${compose_file}"
   echo "    working_dir: /root/work" >> "${compose_file}"
 done
-log "🎼" "${compose_file} is noq created"
+log "🎼" "${compose_file} is now created"
 log "🔄" "You can run dx/start to start it up, though you may need to stop it first with Ctrl-C"
 
 # vim: ft=bash

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -109,9 +109,10 @@ module GLI
       def verify_required_options!(flags, command, options)
         missing_required_options = flags.values.
           select(&:required?).
-          reject { |option|
-            options[option.name] != nil
-        }
+          select { |option|
+            options[option.name] == nil ||
+            ( options[option.name].kind_of?(Array) && options[option.name].empty? )
+          }
         unless missing_required_options.empty?
           missing_required_options.sort!
           raise MissingRequiredArgumentsException.new(missing_required_options.map { |option|

--- a/lib/gli/version.rb
+++ b/lib/gli/version.rb
@@ -1,5 +1,5 @@
 module GLI
   unless const_defined? :VERSION
-    VERSION = '2.21.2'
+    VERSION = '2.21.3'
   end
 end

--- a/test/unit/gli_test.rb
+++ b/test/unit/gli_test.rb
@@ -81,6 +81,25 @@ class GLITest < Minitest::Test
 
   end
 
+  def test_command_options_accepting_multiple_values_can_be_required
+    @app.reset
+    @called = false
+    @app.command :foo do |c|
+      c.flag :flag, :required => true, :multiple => true
+      c.action do |global, options, arguments|
+        @called = true
+      end
+    end
+    assert_equal 64, @app.run(['foo']), "Expected exit status to be 64"
+    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
+    assert !@called
+
+    assert_equal 0, @app.run(['foo','--flag=bar']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"
+    assert @called
+
+  end
+
   def test_global_options_can_be_required
     @app.reset
     @called = false
@@ -98,6 +117,25 @@ class GLITest < Minitest::Test
     assert !@called
 
     assert_equal 0, @app.run(['--flag=bar','--other_flag=blah','foo']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"
+    assert @called
+
+  end
+
+  def test_global_options_accepting_multiple_can_be_required
+    @app.reset
+    @called = false
+    @app.flag :flag, :required => true, :multiple => true
+    @app.command :foo do |c|
+      c.action do |global, options, arguments|
+        @called = true
+      end
+    end
+    assert_equal 64, @app.run(['foo']), "Expected exit status to be 64"
+    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
+    assert !@called
+
+    assert_equal 0, @app.run(['--flag=bar','foo']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"
     assert @called
 
   end
@@ -160,6 +198,7 @@ class GLITest < Minitest::Test
     assert called
     raise failure if !failure.nil?
   end
+
 
   def test_command_line_overrides_config
     failure = nil


### PR DESCRIPTION
# Problem

When a flag is `multiple: true` and `required: true`, GLI does not indicate when no flags are given on the command line.

# Solution

Check that the value is an empty array in addition to the nil check
