### PR TITLE
improve error messaging for strict arguments

### DIFF
--- a/lib/gli/command_support.rb
+++ b/lib/gli/command_support.rb
@@ -127,7 +127,7 @@ module GLI
     end
 
     # Executes the command
-    def execute(global_options,options,arguments) 
+    def execute(global_options,options,arguments)
       get_action(arguments).call(global_options,options,arguments)
     end
 

--- a/lib/gli/commands/help_modules/command_help_format.rb
+++ b/lib/gli/commands/help_modules/command_help_format.rb
@@ -31,26 +31,18 @@ module GLI
 SYNOPSIS
 <% synopses.each do |s| %>
     <%= s %>
-<% end %>
-<% unless @command.long_description.nil? %>
+<% end %><% unless @command.long_description.nil? %>
 
 DESCRIPTION
     <%= wrapper.wrap(@command.long_description) %> 
-<% end %>
-<% if options_description.strip.length != 0 %>
-
+<% end %><% if options_description.strip.length != 0 %>
 COMMAND OPTIONS
 <%= options_description %>
-<% end %>
-<% unless @command.commands.empty? %>
-
+<% end %><% unless @command.commands.empty? %>
 COMMANDS
 <%= commands_description %>
-<% end %>
-<% unless @command.examples.empty? %>
-
+<% end %><% unless @command.examples.empty? %>
 <%= @command.examples.size == 1 ? 'EXAMPLE' : 'EXAMPLES' %>
-
 
 <%= command_examples %>
 <% end %>))

--- a/lib/gli/commands/help_modules/global_help_format.rb
+++ b/lib/gli/commands/help_modules/global_help_format.rb
@@ -44,11 +44,9 @@ SYNOPSIS
 VERSION
     <%= @app.version_string %>
 
-<% end %>
-<% unless global_flags_and_switches.empty? %>
+<% end %><% unless global_flags_and_switches.empty? %>
 GLOBAL OPTIONS
 <%= global_option_descriptions %>
-
 <% end %>
 COMMANDS
 <%= commands %>))

--- a/lib/gli/exceptions.rb
+++ b/lib/gli/exceptions.rb
@@ -59,14 +59,45 @@ module GLI
     end
   end
 
-  class MissingRequiredArgumentsException < BadCommandLine
+  class BadCommandOptionsOrArguments < BadCommandLine
     # The command for which the argument was unknown
     attr_reader :command_in_context
-    # +message+:: the error message to show the user
-    # +command+:: the command we were using to parse command-specific options
     def initialize(message,command)
       super(message)
       @command_in_context = command
+    end
+  end
+
+  class MissingRequiredArgumentsException < BadCommandOptionsOrArguments
+    # +message+:: the error message to show the user
+    # +command+:: the command we were using to parse command-specific options
+    def initialize(message,command)
+      super(message,command)
+    end
+  end
+
+  class TooFewArgumentsException < MissingRequiredArgumentsException
+    def initialize(command,num_arguments_received,min_number_of_arguments)
+      message = "#{command.name} expected at least #{min_number_of_arguments} arguments, but was given only #{num_arguments_received}"
+      super(message,command)
+    end
+  end
+  class TooManyArgumentsException < MissingRequiredArgumentsException
+    def initialize(command,num_arguments_received,max_number_of_arguments)
+      message = if max_number_of_arguments == 0
+                  "#{command.name} expected no arguments, but received #{num_arguments_received}"
+                else
+                  "#{command.name} expected only #{max_number_of_arguments} arguments, but received #{num_arguments_received}"
+                end
+      super(message,command)
+    end
+  end
+
+  class MissingRequiredOptionsException < BadCommandOptionsOrArguments
+    def initialize(command,missing_required_options)
+      message = "#{command.name} requires these options: "
+      required_options = missing_required_options.sort.map(&:name).join(", ")
+      super(message + required_options,command)
     end
   end
 

--- a/lib/gli/exceptions.rb
+++ b/lib/gli/exceptions.rb
@@ -69,28 +69,22 @@ module GLI
   end
 
   class MissingRequiredArgumentsException < BadCommandOptionsOrArguments
-    # +message+:: the error message to show the user
-    # +command+:: the command we were using to parse command-specific options
-    def initialize(message,command)
-      super(message,command)
-    end
-  end
+    attr_reader :num_arguments_received, :range_arguments_accepted
+    def initialize(command,num_arguments_received,range_arguments_accepted)
 
-  class TooFewArgumentsException < MissingRequiredArgumentsException
-    def initialize(command,num_arguments_received,min_number_of_arguments)
-      message = "#{command.name} expected at least #{min_number_of_arguments} arguments, but was given only #{num_arguments_received}"
-      super(message,command)
-    end
-  end
-  class TooManyArgumentsException < MissingRequiredArgumentsException
-    def initialize(command,num_arguments_received,max_number_of_arguments)
-      message = if max_number_of_arguments == 0
-                  "#{command.name} expected no arguments, but received #{num_arguments_received}"
+      @num_arguments_received   = num_arguments_received
+      @range_arguments_accepted = range_arguments_accepted
+
+      message = if @num_arguments_received < @range_arguments_accepted.min
+                  "#{command.name} expected at least #{@range_arguments_accepted.min} arguments, but was given only #{@num_arguments_received}"
+                elsif @range_arguments_accepted.min == 0
+                  "#{command.name} expected no arguments, but received #{@num_arguments_received}"
                 else
-                  "#{command.name} expected only #{max_number_of_arguments} arguments, but received #{num_arguments_received}"
+                  "#{command.name} expected only #{@range_arguments_accepted.max} arguments, but received #{@num_arguments_received}"
                 end
       super(message,command)
     end
+
   end
 
   class MissingRequiredOptionsException < BadCommandOptionsOrArguments

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -98,12 +98,13 @@ module GLI
         end
 
         # Now validate the number of arguments
-        if arguments.size < min_number_of_arguments
-          raise TooFewArgumentsException.new(command,arguments.size,min_number_of_arguments)
+        num_arguments_range = min_number_of_arguments..max_number_of_arguments
+        if !num_arguments_range.cover?(arguments.size)
+          raise MissingRequiredArgumentsException.new(command,arguments.size,num_arguments_range)
         end
-        if arguments.size > max_number_of_arguments
-          raise TooManyArgumentsException.new(command,arguments.size,max_number_of_arguments)
-        end
+        #if arguments.size > max_number_of_arguments
+        #  raise TooManyArgumentsException.new(command,arguments.size,max_number_of_arguments)
+        #end
       end
 
       def verify_required_options!(flags, command, options)

--- a/lib/gli/gli_option_parser.rb
+++ b/lib/gli/gli_option_parser.rb
@@ -99,10 +99,10 @@ module GLI
 
         # Now validate the number of arguments
         if arguments.size < min_number_of_arguments
-          raise MissingRequiredArgumentsException.new("Not enough arguments for command", command)
+          raise TooFewArgumentsException.new(command,arguments.size,min_number_of_arguments)
         end
         if arguments.size > max_number_of_arguments
-          raise MissingRequiredArgumentsException.new("Too many arguments for command", command)
+          raise TooManyArgumentsException.new(command,arguments.size,max_number_of_arguments)
         end
       end
 
@@ -114,10 +114,7 @@ module GLI
             ( options[option.name].kind_of?(Array) && options[option.name].empty? )
           }
         unless missing_required_options.empty?
-          missing_required_options.sort!
-          raise MissingRequiredArgumentsException.new(missing_required_options.map { |option|
-            "#{option.name} is required"
-          }.join(', '), command)
+          raise MissingRequiredOptionsException.new(command,missing_required_options)
         end
       end
     end

--- a/test/integration/gli_powered_app_test.rb
+++ b/test/integration/gli_powered_app_test.rb
@@ -29,7 +29,7 @@ class GLIPoweredAppTest < Minitest::Test
 
   def test_missing_args_exits_nonzero
     out, err, status = run_app("list", expect_failure: true, return_err_and_status: true)
-    assert_match /required_flag is required, required_flag2 is required/,err
+    assert_match /list requires these options: required_flag, required_flag2/,err
     assert_equal 64, status.exitstatus
     assert_match /COMMAND OPTIONS/, out
   end

--- a/test/unit/gli_test.rb
+++ b/test/unit/gli_test.rb
@@ -71,9 +71,8 @@ class GLITest < Minitest::Test
       end
     end
     assert_equal 64, @app.run(['foo']), "Expected exit status to be 64"
-    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
-    assert  @fake_stderr.contained?(/other_flag is required/), @fake_stderr.strings.inspect
-    assert  @fake_stderr.contained?(/flag is required, other_flag is required/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/requires these options.*flag/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/requires these options.*other_flag/), @fake_stderr.strings.inspect
     assert !@called
 
     assert_equal 0, @app.run(['foo','--flag=bar','--other_flag=blah']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"
@@ -91,8 +90,7 @@ class GLITest < Minitest::Test
       end
     end
     assert_equal 64, @app.run(['foo']), "Expected exit status to be 64"
-    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
-    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/requires these options.*flag/), @fake_stderr.strings.inspect
     assert !@called
 
     assert_equal 0, @app.run(['foo','--flag=bar']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"
@@ -111,9 +109,8 @@ class GLITest < Minitest::Test
       end
     end
     assert_equal 64, @app.run(['foo']), "Expected exit status to be 64"
-    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
-    assert  @fake_stderr.contained?(/other_flag is required/), @fake_stderr.strings.inspect
-    assert  @fake_stderr.contained?(/flag is required, other_flag is required/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/requires these options.*flag/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/requires these options.*other_flag/), @fake_stderr.strings.inspect
     assert !@called
 
     assert_equal 0, @app.run(['--flag=bar','--other_flag=blah','foo']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"
@@ -131,8 +128,7 @@ class GLITest < Minitest::Test
       end
     end
     assert_equal 64, @app.run(['foo']), "Expected exit status to be 64"
-    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
-    assert  @fake_stderr.contained?(/flag is required/), @fake_stderr.strings.inspect
+    assert  @fake_stderr.contained?(/requires these options.*flag/), @fake_stderr.strings.inspect
     assert !@called
 
     assert_equal 0, @app.run(['--flag=bar','foo']), "Expected exit status to be 0 #{@fake_stderr.strings.join(',')}"

--- a/test/unit/subcommand_parsing_test.rb
+++ b/test/unit/subcommand_parsing_test.rb
@@ -78,8 +78,8 @@ class SubcommandParsingTest < Minitest::Test
     setup_app_with_subcommand_storing_results :normal, false, :strict
     @app.run(%w(-f global command -f flag -s subcomm  -f subflag))
     with_clue {
+      assert       @fake_stderr.contained?(/expected no arguments, but received 3/)
       assert_equal nil,@results[:command_name]
-      assert       @fake_stderr.contained?(/error: Too many arguments for command/)
     }
   end
 
@@ -123,8 +123,8 @@ class SubcommandParsingTest < Minitest::Test
       with_clue {
         assert_equal number_generated, @results[:number_of_args_give_to_action]
         assert_equal 0, @exit_code
-        assert !@fake_stderr.contained?(/Not enough arguments for command/)
-        assert !@fake_stderr.contained?(/Too many arguments for command/)
+        assert !@fake_stderr.contained?(/expected at least/)
+        assert !@fake_stderr.contained?(/expected only/)
       }
     end
   end
@@ -144,11 +144,15 @@ class SubcommandParsingTest < Minitest::Test
         if status == :not_enough then
           assert_nil @results[:number_of_args_give_to_action]
           assert_equal 64, @exit_code
-          assert @fake_stderr.contained?(/Not enough arguments for command/)
+          assert @fake_stderr.contained?(/expected at least #{number_required} arguments, but was given only #{number_generated}/)
         elsif status == :too_many then
           assert_nil @results[:number_of_args_give_to_action]
           assert_equal 64, @exit_code
-          assert @fake_stderr.contained?(/Too many arguments for command/)
+          if number_required == 0
+            assert @fake_stderr.contained?(/expected no arguments, but received #{number_generated}/)
+          else
+            assert @fake_stderr.contained?(/expected only #{number_required + number_optional} arguments, but received #{number_generated}/)
+          end
         else
           assert false
         end

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -1,5 +1,6 @@
 require "minitest/autorun"
 require "gli"
+require "pp"
 
 module TestHelper
   class CLIApp


### PR DESCRIPTION
# Problem

When using strict arguments and the app doesn't receive the proper amount, the error message produced is
not super helpful about what was received and what was expected

# Solution

Change error messages as follows

* too few - `command «command name» expected at least XXX arguments, but was given only YYY`
* too many - `command «command name» expected only XXX arguments, but was given only YYY`

Also, clean up some whitespace issues
