### PR TITLE
Explicitly require HTTPS rubygems source

### DIFF
--- a/test/apps/todo_legacy/Gemfile
+++ b/test/apps/todo_legacy/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Use HTTPS rubygems.org source to help prevent MITM attacks