### PR TITLE
Add ostruct as dependency for Ruby >=3.3.

### DIFF
--- a/gli.gemspec
+++ b/gli.gemspec
@@ -31,6 +31,8 @@ spec = Gem::Specification.new do |s|
   s.bindir      = "exe"
   s.executables = "gli"
 
+  s.add_dependency("ostruct")
+
   s.add_development_dependency("rake")
   s.add_development_dependency("rdoc")
   s.add_development_dependency("rainbow", "~> 1.1", "~> 1.1.1")


### PR DESCRIPTION
I've updated to Ruby 3.3 and noticed the following warning:

```
/nix/store/371bn7gv9i3gr68rlwr7qxnaxa4x4d58-ruby3.3-gli-2.22.0/lib/ruby/gems/3.3.0/gems/gli-2.22.0/lib/gli.rb:14: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

So I guess it is inevitable to add it as a dependency.