### PR TITLE
Fix `homepage_uri` in gemspec

### DIFF
--- a/gli.gemspec
+++ b/gli.gemspec
@@ -16,7 +16,7 @@ spec = Gem::Specification.new do |s|
     'bug_tracker_uri'   => 'https://github.com/davetron5000/gli/issues',
     'changelog_uri'     => 'https://github.com/davetron5000/gli/releases',
     'documentation_uri' => 'https://davetron5000.github.io/gli/rdoc/index.html',
-    'homepage_uri'      => 'https://davetron5000.github.com/gli/',
+    'homepage_uri'      => 'https://davetron5000.github.io/gli/',
     'source_code_uri'   => 'https://github.com/davetron5000/gli/',
     'wiki_url'          => 'https://github.com/davetron5000/gli/wiki',
   }


### PR DESCRIPTION
Hello!

I am currently developing a Ruby application for work, and I am using the [compare_linker gem](https://github.com/masutaka/compare_linker) to check for updates on dependency gems. We also use the gli gem in this application, and I attempted to update its version. However, I encountered an issue because the domain listed in the `homepage_uri` within the gemspecs, `davetron5000.github.com`, does not exist, which caused compare_linker to throw an error. You can see this at:
https://github.com/davetron5000/gli/blob/v2.22.1/gli.gemspec#L19

Could you please check the relevant section and update it to a URL that is accessible?

Thank you for reading this.